### PR TITLE
Remove units of string based sensors

### DIFF
--- a/custom_components/pijuice/sensor.py
+++ b/custom_components/pijuice/sensor.py
@@ -55,11 +55,11 @@ SENSOR_IO_CURRENT = "io_current"
 SENSOR_LIST = {
     # [name, device class, state class, unit, icon, index, size]
     SENSOR_BATTERY_STATUS:
-        ['Battery status',        '',                       '',                      '',                      "mdi:flash",       0x40, 1],
+        ['Battery status',        '',                       '',                      None,                    "mdi:flash",       0x40, 1],
     SENSOR_POWER_STATUS:
-        ['Power input status',    '',                       '',                      '',                      "mdi:power-plug",  0x40, 1],
+        ['Power input status',    '',                       '',                      None,                    "mdi:power-plug",  0x40, 1],
     SENSOR_POWER_IO_STATUS:
-        ['Power input IO status', '',                       '',                      '',                      "mdi:power-plug",  0x40, 1],
+        ['Power input IO status', '',                       '',                      None,                    "mdi:power-plug",  0x40, 1],
     SENSOR_CHARGE:
         ['Charge',                DEVICE_CLASS_BATTERY,     STATE_CLASS_MEASUREMENT, PERCENTAGE,              "mdi:battery",     0x41, 1],
     SENSOR_TEMP:


### PR DESCRIPTION
Fixes recording of the status sensors, as empty units `""` make HA expect numeric values

Changes UI from:
![image](https://user-images.githubusercontent.com/23134999/195547187-71f46009-b02d-49a7-9a25-8c5568b74a0b.png)
to:
![image](https://user-images.githubusercontent.com/23134999/195547513-b5052378-33f2-4bb0-9bd2-0895175f47c7.png)
