### PR TITLE
Avoid leaking file descriptors

### DIFF
--- a/custom_components/pijuice/sensor.py
+++ b/custom_components/pijuice/sensor.py
@@ -215,8 +215,8 @@ class PiJuiceSensor(SensorEntity):
         i2c_bus = int(self._config.get(CONF_I2C_BUS))
         
         try:
-            bus = SMBus(i2c_bus)
-            data = bus.read_i2c_block_data(i2c_address, self._index, self._size)
+            with SMBus(i2c_bus) as bus:
+                data = bus.read_i2c_block_data(i2c_address, self._index, self._size)
             
             # Scale red values
             if self._sensor == SENSOR_BATTERY_STATUS:


### PR DESCRIPTION
Use "with" when opening SMBus(i2c_bus) to close the bus after use and avoid leaking of file descriptors.